### PR TITLE
Remove sudo use and set volume ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project spins up a four-node ClickHouse cluster (two shards, two replicas) 
 
 ## Requirements
 - Docker with Docker Compose plugin
-- `sudo` privileges
+- Access to the `docker` command (e.g., your user is in the `docker` group or you are using rootless Docker)
 
 ## Usage
 Run the provided script to create required directories and start the cluster:
@@ -28,5 +28,5 @@ Individual nodes are mapped for debugging:
 To stop and remove containers:
 
 ```bash
-sudo docker compose down
+docker compose down
 ```

--- a/start.sh
+++ b/start.sh
@@ -8,12 +8,23 @@ set +o allexport
 VOLUMES_DIR=${VOLUMES_DIR:-./volumes}
 CLICKHOUSE_NODES=(node1 node2 node3 node4)
 
-# create data directories with root ownership
+# Requires permission to run Docker commands.
+# Ensure your user is in the 'docker' group or that you are using rootless Docker.
+
+# determine container UIDs/GIDs
+CH_UID=$(docker run --rm "${CH_IMAGE}:${CH_VERSION}" id -u)
+CH_GID=$(docker run --rm "${CH_IMAGE}:${CH_VERSION}" id -g)
+ZK_UID=$(docker run --rm "${ZK_IMAGE}:${ZK_VERSION}" id -u)
+ZK_GID=$(docker run --rm "${ZK_IMAGE}:${ZK_VERSION}" id -g)
+
+# create data directories with appropriate ownership
 for node in "${CLICKHOUSE_NODES[@]}"; do
-    sudo mkdir -p "${VOLUMES_DIR}/clickhouse/${node}"
+    mkdir -p "${VOLUMES_DIR}/clickhouse/${node}"
 done
-sudo mkdir -p "${VOLUMES_DIR}/zookeeper/data" "${VOLUMES_DIR}/zookeeper/datalog"
-sudo chown -R root:root "${VOLUMES_DIR}"
+mkdir -p "${VOLUMES_DIR}/zookeeper/data" "${VOLUMES_DIR}/zookeeper/datalog"
+
+chown -R "${CH_UID}:${CH_GID}" "${VOLUMES_DIR}/clickhouse"
+chown -R "${ZK_UID}:${ZK_GID}" "${VOLUMES_DIR}/zookeeper"
 
 # start cluster
-sudo docker compose up -d
+docker compose up -d


### PR DESCRIPTION
## Summary
- remove sudo from start script and set volume ownership based on container UID/GID
- document docker group/rootless requirement and drop sudo from README examples

## Testing
- `bash -n start.sh`


------
https://chatgpt.com/codex/tasks/task_e_688f6495beb083229ea504e3641d6145