### PR TITLE
Fix ZooKeeper data directory paths

### DIFF
--- a/config/zookeeper/zoo.cfg
+++ b/config/zookeeper/zoo.cfg
@@ -1,6 +1,6 @@
 tickTime=2000
-dataDir=/var/lib/zookeeper/data
-dataLogDir=/var/lib/zookeeper/log
+dataDir=/data
+dataLogDir=/datalog
 clientPort=2181
 initLimit=5
 syncLimit=2


### PR DESCRIPTION
## Summary
- align ZooKeeper `dataDir` and `dataLogDir` with container volume paths to avoid permission issues

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f9c43d9f48322aa3562318a25f3da