### PR TITLE
Add scripts to stop ClickHouse cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,14 @@ Individual nodes are mapped for debugging:
 - ch3: ports 9003/8123
 - ch4: ports 9004/8124
 
-To stop and remove containers:
+To stop the cluster without deleting data, run:
 
 ```bash
-docker compose down
+./stop.sh
+```
+
+To stop the cluster and remove all created data, run:
+
+```bash
+./stop-clean.sh
 ```

--- a/stop-clean.sh
+++ b/stop-clean.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+set -o allexport
+[ -f .env ] && source .env
+set +o allexport
+
+VOLUMES_DIR=${VOLUMES_DIR:-./volumes}
+
+# stop cluster and remove containers, networks, and volumes
+docker compose down -v
+
+# remove data directories if they exist and path is safe
+if [[ -n "$VOLUMES_DIR" && "$VOLUMES_DIR" != "/" ]]; then
+    rm -rf -- "$VOLUMES_DIR"
+fi

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+set -o allexport
+[ -f .env ] && source .env
+set +o allexport
+
+# stop cluster
+docker compose down


### PR DESCRIPTION
## Summary
- add stop.sh to stop the cluster
- add stop-clean.sh to stop the cluster and remove data directories
- document new scripts in README

## Testing
- `shellcheck start.sh stop.sh stop-clean.sh`
- `./stop.sh` *(fails: 'compose' is not a docker command)*
- `./stop-clean.sh` *(prints Docker version; compose plugin unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_688fb5870e1c83229dce294c1cf6a712